### PR TITLE
Added IP address and port as arguments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "3.1.2", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ const DEFAULT_IP: &str = "127.0.0.1";
 const DEFAULT_PORT: &str = "8080";
 
 #[derive(Parser)]
-#[clap(author, version)]
+#[clap(version)]
 struct Args {
     /// JSON file to load
     json_filename: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
+use clap::Parser;
 use std::fs;
-use std::env;
-use std::process;
 use std::io::prelude::*;
 use std::net::TcpListener;
 use std::net::TcpStream;
@@ -8,20 +7,31 @@ use std::net::TcpStream;
 const DEFAULT_IP: &str = "127.0.0.1";
 const DEFAULT_PORT: &str = "8080";
 
+#[derive(Parser)]
+#[clap(author, version)]
+struct Args {
+    /// JSON file to load
+    json_filename: String,
+
+    /// IP address
+    #[clap(short, long)]
+    ip_address: Option<String>,
+
+    /// Port
+    #[clap(short, long)]
+    port: Option<String>,
+}
+
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    if args.len() <= 1 {
-        println!("No .json file was provided as argument!");
-        process::exit(0);
-    }
+    let args = Args::parse();
 
+    let ip_address = args.ip_address.unwrap_or(DEFAULT_IP.to_string());
+    let port = args.port.unwrap_or(DEFAULT_PORT.to_string());
 
-    let json_filename = &args[1];
-    let json_content = fs::read_to_string(json_filename).unwrap();
+    let listener = TcpListener::bind(format!("{}:{}", ip_address, port)).unwrap();
+    println!("\tServer started at http://{}:{}", ip_address, port);
 
-    let listener = TcpListener::bind(format!("{}:{}", DEFAULT_IP, DEFAULT_PORT)).unwrap();
-    println!("\tServer started at http://{}:{}", DEFAULT_IP, DEFAULT_PORT);
-
+    let json_content = fs::read_to_string(args.json_filename).unwrap();
     for stream in listener.incoming() {
         handle_connection(stream.unwrap(), &json_content);
     }


### PR DESCRIPTION
Closes #12
IP address and port as arguments added using the library [clap](https://github.com/clap-rs/clap). It can be rewritten later to remove the dependency.